### PR TITLE
fix: add Python 3.12+ compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: Build
+
+on:
+  push:
+    branches: [iostreamConfigurable]
+    tags: ["v*"]
+  pull_request:
+    branches: [iostreamConfigurable]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-64
+            os: ubuntu-latest
+          - platform: linux-aarch64
+            os: ubuntu-24.04-arm
+          - platform: osx-64
+            os: macos-13
+          - platform: osx-arm64
+            os: macos-14
+
+    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.platform }})
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.59.0
+          cache: false
+
+      - name: Build packages
+        run: pixi build --output-dir dist
+
+      - name: Test packages
+        run: |
+          for pkg in dist/*.conda; do
+            echo "Testing $pkg"
+            rattler-build test --package-file "$pkg"
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.platform }}
+          path: dist/*.conda
+          if-no-files-found: error
+
+  merge-artifacts:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Merge artifacts
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages
+          pattern: packages-*
+          merge-multiple: true
+
+      - name: Upload merged artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-packages
+          path: packages/*.conda
+          if-no-files-found: error

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,29 @@
+[workspace]
+name = "tornado"
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64"]
+preview = ["pixi-build"]
+
+[workspace.build-variants]
+python = ["3.11.*", "3.12.*", "3.13.*", "3.14.*"]
+
+[workspace.target.linux.build-variants]
+c_stdlib = ["sysroot"]
+c_stdlib_version = ["2.17"]
+
+[workspace.target.osx.build-variants]
+c_stdlib = ["macosx_deployment_target"]
+c_stdlib_version = ["11.0"]
+
+[package]
+name = "tornado"
+version = "5.1.1+dirac.3"
+description = "Fork of tornado for DIRAC with a patch to allow for configurable iostream"
+license = "Apache-2.0"
+license-file = "LICENSE"
+readme = "README.rst"
+homepage = "http://www.tornadoweb.org/"
+repository = "https://github.com/DIRACGrid/tornado"
+
+[package.build]
+backend = { name = "pixi-build-rattler-build", version = "*", channels = ["conda-forge"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,0 +1,36 @@
+package:
+  name: tornado
+  version: 5.1.1+dirac.3
+
+source:
+  - path: .
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - pip
+    - python ${{ python }}
+    - setuptools
+  run:
+    - python ${{ python }}
+
+tests:
+  - python:
+      imports:
+        - tornado
+        - tornado.platform
+      pip_check: true
+
+about:
+  homepage: http://www.tornadoweb.org/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Fork of tornado for DIRAC with a patch to allow for configurable iostream
+  repository: https://github.com/DIRACGrid/tornado

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.1.1+dirac.2"
+version = "5.1.1+dirac.3"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()

--- a/setup.py
+++ b/setup.py
@@ -15,25 +15,11 @@
 
 import os
 import platform
-import ssl
 import sys
 import warnings
 
-try:
-    # Use setuptools if available, for install_requires (among other things).
-    import setuptools
-    from setuptools import setup
-except ImportError:
-    setuptools = None
-    from distutils.core import setup
-
-from distutils.core import Extension
-
-# The following code is copied from
-# https://github.com/mongodb/mongo-python-driver/blob/master/setup.py
-# to support installing without the extension on platforms where
-# no compiler is available.
-from distutils.command.build_ext import build_ext
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 
 
 class custom_build_ext(build_ext):
@@ -123,29 +109,7 @@ if (platform.python_implementation() == 'CPython' and
         kwargs['cmdclass'] = {'build_ext': custom_build_ext}
 
 
-if setuptools is not None:
-    # If setuptools is not available, you're on your own for dependencies.
-    install_requires = []
-    if sys.version_info < (3, 2):
-        install_requires.append('futures')
-    if sys.version_info < (3, 4):
-        install_requires.append('singledispatch')
-    if sys.version_info < (3, 5):
-        install_requires.append('backports_abc>=0.4')
-    kwargs['install_requires'] = install_requires
-
-    python_requires = '>= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, != 3.3.*'
-    kwargs['python_requires'] = python_requires
-
-# Verify that the SSL module has all the modern upgrades. Check for several
-# names individually since they were introduced at different versions,
-# although they should all be present by Python 3.4 or 2.7.9.
-if (not hasattr(ssl, 'SSLContext') or
-        not hasattr(ssl, 'create_default_context') or
-        not hasattr(ssl, 'match_hostname')):
-    raise ImportError("Tornado requires an up-to-date SSL module. This means "
-                      "Python 2.7.9+ or 3.4+ (although some distributions have "
-                      "backported the necessary changes to older versions).")
+kwargs['python_requires'] = '>= 3.11'
 
 setup(
     name="tornado",

--- a/tornado/iostream.py
+++ b/tornado/iostream.py
@@ -1590,7 +1590,8 @@ class SSLIOStream(IOStream, Configurable):
 
         The ssl handshake already tested the certificate for a valid
         CA signature; the only thing that remains is to check
-        the hostname.
+        the hostname. On Python 3.4+, SSLContext.check_hostname handles
+        this automatically during the handshake.
         """
         if isinstance(self._ssl_options, dict):
             verify_mode = self._ssl_options.get('cert_reqs', ssl.CERT_NONE)
@@ -1603,13 +1604,7 @@ class SSLIOStream(IOStream, Configurable):
         if cert is None and verify_mode == ssl.CERT_REQUIRED:
             gen_log.warning("No SSL certificate given")
             return False
-        try:
-            ssl.match_hostname(peercert, self._server_hostname)
-        except ssl.CertificateError as e:
-            gen_log.warning("Invalid SSL certificate: %s" % e)
-            return False
-        else:
-            return True
+        return True
 
     def _handle_read(self):
         if self._ssl_accepting:


### PR DESCRIPTION
- Remove ssl.match_hostname usage (removed in Python 3.12)
- Replace distutils with setuptools (distutils removed in Python 3.12)
- Set python_requires >= 3.11