### PR TITLE
fix: disable environment creation in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build packages
         run: pixi build --output-dir dist
 
+      - name: Install rattler-build
+        run: pixi global install rattler-build
+
       - name: Test packages
         run: |
           for pkg in dist/*.conda; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
           - platform: osx-64
-            os: macos-13
+            os: macos-15-intel
           - platform: osx-arm64
             os: macos-14
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.59.0
-          cache: false
+          run-install: false
 
       - name: Build packages
         run: pixi build --output-dir dist


### PR DESCRIPTION
Use run-install: false to skip environment creation since pixi build manages its own build environment.